### PR TITLE
Fix Windows warnings. No -Werror yet. :(

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,11 +255,11 @@ if(WIN32)
         set(GUI_TYPE WIN32)
     endif()
 
-    include_directories( libs/toktok/include libs/windows-x64/include/ )
+    include_directories(SYSTEM libs/toktok/include libs/windows-x64/include/)
     if(WIN64)
-        link_directories( libs/toktok/lib /usr/x86_64-w64-mingw32/lib/ libs/windows-x64/lib )
+        link_directories(libs/toktok/lib /usr/x86_64-w64-mingw32/lib/ libs/windows-x64/lib)
     else()
-        link_directories( libs/toktok_32/lib /usr/i686-w64-mingw32/lib/ libs/windows-x32/lib )
+        link_directories(libs/toktok_32/lib /usr/i686-w64-mingw32/lib/ libs/windows-x32/lib)
     endif()
 
     ## Needed to build the widows icon

--- a/cmake/toolchain-win32.cmake
+++ b/cmake/toolchain-win32.cmake
@@ -24,7 +24,7 @@ set(UTOX_STATIC ON CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g3" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -g3" CACHE STRING "" FORCE)
 
-set(INCLUDE_DIRECTORIES SYSTEM /usr/share/mingw-w64/include/)
+include_directories(SYSTEM /usr/share/mingw-w64/include/)
 
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search

--- a/cmake/toolchain-win64.cmake
+++ b/cmake/toolchain-win64.cmake
@@ -24,7 +24,7 @@ set(UTOX_STATIC ON CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g3" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -g3" CACHE STRING "" FORCE)
 
-set(INCLUDE_DIRECTORIES SYSTEM /usr/share/mingw-w64/include/)
+include_directories(SYSTEM /usr/share/mingw-w64/include/)
 
 # adjust the default behaviour of the FIND_XXX() commands:
 # search headers and libraries in the target environment, search

--- a/extra/gitlab/windows-script.sh
+++ b/extra/gitlab/windows-script.sh
@@ -10,5 +10,5 @@ cd build_win
 cmake .. \
     -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchain-win64.cmake \
     -DENABLE_TESTS=OFF \
-    -DENABLE_WERROR=ON
+    -DENABLE_WERROR=OFF
 make

--- a/src/windows/main.7.c
+++ b/src/windows/main.7.c
@@ -124,13 +124,13 @@ void launch_at_startup(bool should) {
             path_length += 2;
 
             // 2 bytes per wchar_t
-            uint16_t ret = RegSetKeyValueW(hKey, NULL, L"uTox", REG_SZ, path, path_length * 2);
+            RegSetKeyValueW(hKey, NULL, L"uTox", REG_SZ, path, path_length * 2);
             RegCloseKey(hKey);
         }
     } else {
         HKEY hKey;
-        if (ERROR_SUCCESS == RegOpenKeyW(HKEY_CURRENT_USER, run_key_path, &hKey)) {
-            uint16_t ret = RegDeleteKeyValueW(hKey, NULL, L"uTox");
+        if (RegOpenKeyW(HKEY_CURRENT_USER, run_key_path, &hKey) == ERROR_SUCCESS) {
+            RegDeleteKeyValueW(hKey, NULL, L"uTox");
             RegCloseKey(hKey);
         }
     }

--- a/src/windows/notify.c
+++ b/src/windows/notify.c
@@ -55,9 +55,6 @@ static void redraw_notify(UTOX_WINDOW *win) {
 }
 
 LRESULT CALLBACK notify_msg_sys(HWND window, UINT msg, WPARAM wParam, LPARAM lParam) {
-    UTOX_WINDOW *win = native_window_find_notify(&window);
-
-    static int mdown_x, mdown_y;
     switch (msg) {
         case WM_QUIT:
         case WM_CLOSE:
@@ -71,6 +68,7 @@ LRESULT CALLBACK notify_msg_sys(HWND window, UINT msg, WPARAM wParam, LPARAM lPa
         }
 
         case WM_CREATE: {
+            UTOX_WINDOW *win = native_window_find_notify(&window);
             if (win) {
                 win->window_DC = GetDC(window);
                 win->draw_DC   = CreateCompatibleDC(win->window_DC);
@@ -92,6 +90,7 @@ LRESULT CALLBACK notify_msg_sys(HWND window, UINT msg, WPARAM wParam, LPARAM lPa
                 w = r.right;
                 h = r.bottom;
 
+                UTOX_WINDOW *win = native_window_find_notify(&window);
                 if (win) {
                     if (win->draw_BM) {
                         DeleteObject(win->draw_BM);
@@ -104,17 +103,19 @@ LRESULT CALLBACK notify_msg_sys(HWND window, UINT msg, WPARAM wParam, LPARAM lPa
         }
 
         case WM_ERASEBKGND: {
+            UTOX_WINDOW *win = native_window_find_notify(&window);
             redraw_notify(win);
             return true;
         }
 
         case WM_PAINT: {
             PAINTSTRUCT ps;
-
             BeginPaint(window, &ps);
 
+            UTOX_WINDOW *win = native_window_find_notify(&window);
             RECT r = ps.rcPaint;
-            BitBlt(win->window_DC, r.left, r.top, r.right - r.left, r.bottom - r.top, win->draw_DC, r.left, r.top, SRCCOPY);
+            BitBlt(win->window_DC, r.left, r.top, r.right - r.left, r.bottom - r.top,
+                   win->draw_DC, r.left, r.top, SRCCOPY);
 
             EndPaint(window, &ps);
             return false;
@@ -125,12 +126,11 @@ LRESULT CALLBACK notify_msg_sys(HWND window, UINT msg, WPARAM wParam, LPARAM lPa
         }
 
         case WM_LBUTTONDOWN: {
-            mdown_x = GET_X_LPARAM(lParam);
-            mdown_y = GET_Y_LPARAM(lParam);
             break;
         }
         case WM_LBUTTONUP: {
             ReleaseCapture();
+            UTOX_WINDOW *win = native_window_find_notify(&window);
             redraw_notify(win);
             break;
         }


### PR DESCRIPTION
TODO: Update mingw-w64 to allow adding -Werror. The last warning is because of a bug in their Windows headers, but it's been fixed in a recent-ish version.