### PR TITLE
Build OS X Toxcore with ASAN.

### DIFF
--- a/extra/travis/osx-before.sh
+++ b/extra/travis/osx-before.sh
@@ -30,7 +30,7 @@ cd toxcore
 git rev-parse HEAD > toxcore.sha
 if ! ([ -f "$CACHE_DIR/toxcore.sha" ] && diff "$CACHE_DIR/toxcore.sha" toxcore.sha); then
   mkdir _build
-  cmake -B_build -H. -DCMAKE_INSTALL_PREFIX:PATH="$CACHE_DIR/usr"
+  cmake -B_build -H. -DCMAKE_INSTALL_PREFIX:PATH="$CACHE_DIR/usr" -DASAN=1
   make -C_build -j`sysctl -n hw.ncpu`
   make -C_build install
   mv toxcore.sha "$CACHE_DIR/toxcore.sha"


### PR DESCRIPTION
This is a workaround to the OS X builds failing because it can't find the `-z` ld flag.