### PR TITLE
 Update conference callbacks for Toxcore 0.2.0

### DIFF
--- a/src/av/audio.c
+++ b/src/av/audio.c
@@ -836,8 +836,10 @@ void utox_audio_thread(void *args) {
     free(preview_buffer);
 }
 
-void callback_av_group_audio(void *UNUSED(tox), int groupnumber, int peernumber, const int16_t *pcm, unsigned int samples,
-                             uint8_t channels, unsigned int sample_rate, void *UNUSED(userdata))
+void callback_av_group_audio(
+        void *UNUSED(tox), uint32_t groupnumber, uint32_t peernumber,
+        const int16_t *pcm, unsigned samples, uint8_t channels,
+        uint32_t sample_rate, void *UNUSED(userdata))
 {
     GROUPCHAT *g = get_group(groupnumber);
     if (!g || !g->active_call) {

--- a/src/av/utox_av.h
+++ b/src/av/utox_av.h
@@ -69,8 +69,10 @@ void utox_av_local_call_control(ToxAV *av, uint32_t friend_number, TOXAV_CALL_CO
 
 void set_av_callbacks(ToxAV *av);
 
-void callback_av_group_audio(void *tox, int groupnumber, int peernumber, const int16_t *pcm, unsigned int samples,
-                                    uint8_t channels, unsigned int sample_rate, void *userdata);
+void callback_av_group_audio(
+        void *tox, uint32_t groupnumber,
+        uint32_t peernumber, const int16_t *pcm, unsigned samples,
+        uint8_t channels, uint32_t sample_rate, void *userdata);
 
 void group_av_peer_add(GROUPCHAT *g, int peernumber);
 void group_av_peer_remove(GROUPCHAT *g, int peernumber);

--- a/src/tox_callbacks.c
+++ b/src/tox_callbacks.c
@@ -129,9 +129,6 @@ void utox_set_callbacks_friends(Tox *tox) {
     tox_callback_friend_connection_status(tox, callback_connection_status);
 }
 
-void callback_av_group_audio(void *tox, int groupnumber, int peernumber, const int16_t *pcm, unsigned int samples,
-                             uint8_t channels, unsigned int sample_rate, void *userdata);
-
 static void callback_group_invite(Tox *tox, uint32_t fid, TOX_CONFERENCE_TYPE type, const uint8_t *data, size_t length,
                                   void *UNUSED(userdata))
 {

--- a/src/tox_callbacks.c
+++ b/src/tox_callbacks.c
@@ -13,7 +13,7 @@
 #include "av/audio.h"
 #include "av/utox_av.h"
 
-
+#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -172,108 +172,67 @@ static void callback_group_message(Tox *UNUSED(tox), uint32_t gid, uint32_t pid,
     postmessage_utox(GROUP_MESSAGE, gid, pid, NULL);
 }
 
-static void callback_group_namelist_change(Tox *tox, uint32_t gid, uint32_t pid,
-                                           TOX_CONFERENCE_STATE_CHANGE change,
-                                           void *UNUSED(userdata))
+static void callback_group_peer_name_change(
+        Tox *UNUSED(tox),
+        uint32_t gid,
+        uint32_t pid,
+        const uint8_t *name,
+        size_t length,
+        void *UNUSED(userdata))
 {
     GROUPCHAT *g = get_group(gid);
     if (!g) {
+        assert(false);
         return;
     }
 
-    switch (change) {
-        case TOX_CONFERENCE_STATE_CHANGE_PEER_JOIN: {
-            if (g->peer) {
-                g->peer = realloc(g->peer, sizeof(void *) * (g->peer_count + 2));
-            } else {
-                g->peer = calloc(g->peer_count + 2, sizeof(void *));
-            }
-            bool is_us = 0;
-            if (tox_conference_peer_number_is_ours(tox, gid, pid, 0)) {
-                g->our_peer_number = pid;
-                is_us              = 1;
-            }
+    length = utf8_validate(name, length);
+    group_peer_name_change(g, pid, name, length);
 
-            uint8_t pkey[TOX_PUBLIC_KEY_SIZE];
-            tox_conference_peer_get_public_key(tox, gid, pid, pkey, NULL);
-            uint64_t pkey_to_number = 0;
-            int      key_i          = 0;
-            for (; key_i < TOX_PUBLIC_KEY_SIZE; ++key_i) {
-                pkey_to_number += pkey[key_i];
-            }
-            srand(pkey_to_number);
-            uint32_t name_color = 0;
-            name_color          = RGB(rand(), rand(), rand());
+    postmessage_utox(GROUP_PEER_NAME, gid, pid, NULL);
+}
 
-            group_peer_add(g, pid, is_us, name_color);
-
-            postmessage_utox(GROUP_PEER_ADD, gid, pid, NULL);
-            break;
-        }
-
-        case TOX_CONFERENCE_STATE_CHANGE_PEER_NAME_CHANGE: {
-            if (g->peer) {
-                if (!g->peer[pid]) {
-                    break;
-                }
-            }
-
-            uint8_t name[TOX_MAX_NAME_LENGTH];
-            size_t len = tox_conference_peer_get_name_size(tox, gid, pid, NULL);
-            tox_conference_peer_get_name(tox, gid, pid, name, NULL);
-            len = utf8_validate(name, len);
-            group_peer_name_change(g, pid, name, len);
-
-            postmessage_utox(GROUP_PEER_NAME, gid, pid, NULL);
-            break;
-        }
-
-        case TOX_CONFERENCE_STATE_CHANGE_PEER_EXIT: {
-            group_add_message(g, pid, (const uint8_t *)"<- has Quit!", 12, MSG_TYPE_NOTICE);
-
-            pthread_mutex_lock(&messages_lock); /* make sure that messages has posted before we continue */
-
-            group_reset_peerlist(g);
-
-            uint32_t number_peers = tox_conference_peer_count(tox, gid, NULL);
-
-            g->peer = calloc(number_peers, sizeof(void *));
-
-            if (!g->peer) {
-                exit(1);
-            }
-
-            /* I'm about to break some uTox style here, because I'm expecting
-             * the API to change soon, and I just can't when it's this broken */
-            for (uint32_t i = 0; i < number_peers; ++i) {
-                uint8_t     tmp[TOX_MAX_NAME_LENGTH];
-                size_t      len  = tox_conference_peer_get_name_size(tox, gid, i, NULL);
-                tox_conference_peer_get_name(tox, gid, i, tmp, NULL);
-                GROUP_PEER *peer = calloc(1, len * sizeof(void *) + sizeof(*peer));
-                /* name and id number (it's worthless, but it's needed */
-                memcpy(peer->name, tmp, len);
-                peer->name_length = len;
-                peer->id          = i;
-                /* get static random color */
-                uint8_t pkey[TOX_PUBLIC_KEY_SIZE];
-                tox_conference_peer_get_public_key(tox, gid, i, pkey, NULL);
-                uint64_t pkey_to_number = 0;
-                for (int key_i = 0; key_i < TOX_PUBLIC_KEY_SIZE; ++key_i) {
-                    pkey_to_number += pkey[key_i];
-                }
-                /* uTox doesnt' really use this for too much so lets fuck with the random seed.
-                 * If you know crypto, and cringe, I know me too... you can blame @irungentoo */
-                srand(pkey_to_number);
-                peer->name_color = RGB(rand(), rand(), rand());
-                g->peer[i]       = peer;
-            }
-            g->peer_count = number_peers;
-
-            postmessage_utox(GROUP_PEER_DEL, gid, pid, NULL);
-            pthread_mutex_unlock(&messages_lock); /* make sure that messages has posted before we continue */
-            break;
-        }
+static void callback_group_peer_list_changed(Tox *tox, uint32_t gid, void *UNUSED(userdata)){
+    GROUPCHAT *g = get_group(gid);
+    if (!g) {
+        assert(false);
+        return;
     }
+
+    pthread_mutex_lock(&messages_lock);
+    group_reset_peerlist(g);
+
+    uint32_t number_peers = tox_conference_peer_count(tox, gid, NULL);
+
+    g->peer = calloc(number_peers, sizeof(void *));
+    g->peer_count = number_peers;
+
+    for (uint32_t i = 0; i < number_peers; ++i) {
+        uint8_t tmp[TOX_MAX_NAME_LENGTH];
+        size_t len = tox_conference_peer_get_name_size(tox, gid, i, NULL);
+        tox_conference_peer_get_name(tox, gid, i, tmp, NULL);
+
+        GROUP_PEER *peer = calloc(1, sizeof(*peer) + len + 1);
+        memcpy(peer->name, tmp, len);
+        peer->name_length = len;
+
+        peer->id = i;
+
+        /* get static random color */
+        uint8_t pkey[TOX_PUBLIC_KEY_SIZE];
+        tox_conference_peer_get_public_key(tox, gid, i, pkey, NULL);
+        uint64_t pkey_to_number = 0;
+        for (int key_i = 0; key_i < TOX_PUBLIC_KEY_SIZE; ++key_i) {
+            pkey_to_number += pkey[key_i];
+        }
+        srand(pkey_to_number);
+        peer->name_color = RGB(rand(), rand(), rand());
+
+        g->peer[i] = peer;
+    }
+
+    postmessage_utox(GROUP_PEER_CHANGE, gid, 0, NULL);
+    pthread_mutex_unlock(&messages_lock);
 }
 
 static void callback_group_topic(Tox *UNUSED(tox), uint32_t gid, uint32_t UNUSED(pid),
@@ -292,6 +251,7 @@ static void callback_group_topic(Tox *UNUSED(tox), uint32_t gid, uint32_t UNUSED
 void utox_set_callbacks_groups(Tox *tox) {
     tox_callback_conference_invite(tox, callback_group_invite);
     tox_callback_conference_message(tox, callback_group_message);
-    tox_callback_conference_namelist_change(tox, callback_group_namelist_change);
+    tox_callback_conference_peer_name(tox, callback_group_peer_name_change);
     tox_callback_conference_title(tox, callback_group_topic);
+    tox_callback_conference_peer_list_changed(tox, callback_group_peer_list_changed);
 }

--- a/src/utox.c
+++ b/src/utox.c
@@ -564,7 +564,7 @@ void utox_message_dispatch(UTOX_MSG utox_msg_id, uint16_t param1, uint16_t param
             }
 
             if (g->av_group) {
-                g->last_recv_audio[param2]        = g->last_recv_audio[g->peer_count];
+                g->last_recv_audio[param2] = g->last_recv_audio[g->peer_count];
                 g->last_recv_audio[g->peer_count] = 0;
                 group_av_peer_remove(g, param2);
                 g->source[param2] = g->source[g->peer_count];
@@ -580,6 +580,10 @@ void utox_message_dispatch(UTOX_MSG utox_msg_id, uint16_t param1, uint16_t param
 
             break;
         }
+
+        // param1: group number
+        // param2: peer number
+        case GROUP_PEER_CHANGE:
         case GROUP_PEER_ADD:
         case GROUP_PEER_NAME: {
             GROUPCHAT *g = get_group(param1);

--- a/src/utox.h
+++ b/src/utox.h
@@ -62,6 +62,7 @@ typedef enum utox_msg_id {
     GROUP_PEER_ADD,
     GROUP_PEER_DEL,
     GROUP_PEER_NAME,
+    GROUP_PEER_CHANGE,
     GROUP_TOPIC,
     GROUP_AUDIO_START,
     GROUP_AUDIO_END,


### PR DESCRIPTION
Currently lacking support for the "peer {name} has left the conference" notifications.